### PR TITLE
add priority keyword to `add_system()` method

### DIFF
--- a/ecs/managers.py
+++ b/ecs/managers.py
@@ -157,11 +157,13 @@ class SystemManager(object):
         """
         return self._systems
 
-    def add_system(self, system_instance):
+    def add_system(self, system_instance, priority=0):
         """Add a :class:`ecs.models.System` instance to the manager.
 
         :param system_instance: instance of a system
+        :param priority: non-negative integer (default: 0)
         :type system_instance: :class:`ecs.models.System`
+        :type priority: :class:`int`
         :raises: :class:`ecs.exceptions.DuplicateSystemTypeError` when the
             system type is already present in this manager
         :raises: :class:`ecs.exceptions.SystemAlreadyAddedToManagerError` when
@@ -177,6 +179,9 @@ class SystemManager(object):
         system_instance.system_manager = self
         self._system_types[system_type] = system_instance
         self._systems.append(system_instance)
+
+        system_instance.priority = priority
+        self._systems.sort(key=lambda x: x.priority)
 
     def remove_system(self, system_type):
         """Tell the manager to no longer run the system of this type.

--- a/ecs/models.py
+++ b/ecs/models.py
@@ -43,6 +43,10 @@ class System(object):
         self.system_manager = None
         """The system manager to which this system belongs. Again, a system is
         only allowed to belong to one at a time."""
+        self.priority = None
+        """The priority for this system when the system manager runs
+        :meth:`ecs.managers.SystemManager.update()`. Must be a non-negative
+        integer with 0 being the highest priority."""
 
     @abstractmethod
     def update(self, dt):


### PR DESCRIPTION
```
Add a `priority` attribute to `ecs.models.Systems` and sort
`ecs.managers.SystemManager._systems` by it every time a system is added.
Also add a new test case to ensure that system with the same priority
end up being executed in the order they were added and adjust
`test_systems_added` and `test_remove_system`.  
```

The overhead introduced by the sorting should not be that high, given that Timsort should deal pretty well with partially sorted lists, but I haven't done any benchmarks. The changes to the tests I made may seem blunt as I am unfamiliar with most of the libraries you use there.
