### PR TITLE
Querying for multiple components at once

### DIFF
--- a/ecs/managers.py
+++ b/ecs/managers.py
@@ -72,7 +72,7 @@ class EntityManager(object):
 
     def pairs_for_type(self, *component_types):
         """Return an iterator over ``(entity, component_instances)`` tuples for
-        all entities in the database possessing components of
+        all entities in the database possessing components for every type in
         ``component_types``. Return an empty iterator if there are no
         components of this type in the database. It should be used in a
         loop like this, where ``Renderable`` is a component type:
@@ -85,8 +85,8 @@ entity_manager.pairs_for_type(Renderable):
 
         .. code-block:: python
 
-            for entity, (renderable_component, position_component in \
-entity_manager.pairs_for_type(Renderable,Position):
+            for entity, (renderable_component, position_component) in \
+entity_manager.pairs_for_type(Renderable, Position):
                 pass # do something
 
         :param component_type: a type of created component
@@ -111,12 +111,12 @@ entity_manager.pairs_for_type(Renderable,Position):
             return six.iteritems({})
 
     def component_for_entity(self, entity, *component_types):
-        """Return the instances of ``types`` for the entity from the
+        """Return the instances of ``component_types`` for the entity from the
         database.
 
         :param entity: associated entity
         :type entity: :class:`ecs.models.Entity`
-        :param component_types: a number of types of created components
+        :param component_types: one or more types of created components
         :type component_types: :class:`type` which is :class:`Component`
             subclass
         :return: component instances as tuple or a single component instance

--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -56,10 +56,15 @@ class TestEntityManager(object):
                 (entities[0], components[0]),
                 (entities[1], components[5]),
                 (entities[3], components[0])]
+            assert list(manager.pairs_for_type(component_types[0],
+                        component_types[4])) == [
+                (entities[3], (components[0], components[4]))]
 
         def test_nonexistent_component_type(
                 self, manager, entities, component_types):
             assert list(manager.pairs_for_type(component_types[2])) == []
+            assert list(manager.pairs_for_type(component_types[0],
+                        component_types[3])) == []
 
     class TestRemoveComponent(object):
         def test_remove_some_of_a_component(
@@ -103,11 +108,21 @@ class TestEntityManager(object):
                 self, manager, entities, components, component_types):
             assert manager.component_for_entity(
                 entities[3], component_types[4]) == components[4]
+            assert manager.component_for_entity(
+                entities[3], component_types[4], component_types[0]) == \
+                (components[4], components[0])
 
         def test_raises_error_on_nonexistent_component_type(
                 self, manager, entities, components, component_types):
             with raises(NonexistentComponentTypeForEntity) as exc_info:
                 manager.component_for_entity(entities[3], component_types[1])
+            assert_exc_info_msg(
+                exc_info,
+                "Nonexistent component type: "
+                "`Component1' for entity: `Entity(3)'")
+            with raises(NonexistentComponentTypeForEntity) as exc_info:
+                manager.component_for_entity(entities[3], component_types[0],
+                                             component_types[1])
             assert_exc_info_msg(
                 exc_info,
                 "Nonexistent component type: "


### PR DESCRIPTION
```
EntityManager.{components_for_entity,pairs_for_type} now take a variable
amount of component types. When only one type is given they should behave
exactly as the old version and if not the single component instance is
replaced by a tuple of component instances in the order of the types given.
```

Since I have some free time at hand at the moment, I just went ahead and implemented this one.
